### PR TITLE
Fix formatting warnings

### DIFF
--- a/src/arg.mbt
+++ b/src/arg.mbt
@@ -21,7 +21,7 @@ pub(all) enum Spec {
 fn interpret(
   trie : @trie.T[Spec],
   xs : Array[String],
-  fallback : (String) -> Unit
+  fallback : (String) -> Unit,
 ) -> Unit {
   loop xs[:] {
     [] => ()
@@ -77,7 +77,7 @@ pub fn parse(
   speclist : Array[(String, String, Spec, String)],
   rest : (String) -> Unit,
   usage_msg : String,
-  argv : Array[String]
+  argv : Array[String],
 ) -> Unit {
   let aux = fn(acc, it) {
     let ((trie : @trie.T[Spec]), help_msg) = acc


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

- Add missing trailing commas in function parameter lists
- Fix formatting issues in src/arg.mbt to conform to MoonBit style guidelines
- All tests continue to pass after formatting fixes