### PR TITLE
Fix nightly warning regressions

### DIFF
--- a/pkg.generated.mbti
+++ b/pkg.generated.mbti
@@ -2,10 +2,12 @@
 package "Yoorkin/ArgParser"
 
 // Values
-fn parse(Array[(String, String, Spec, String)], (String) -> Unit raise, String, Array[String]) -> Unit raise
+pub fn parse(Array[(String, String, Spec, String)], (String) -> Unit raise, String, Array[String]) -> Unit raise
 
 // Errors
-pub suberror ErrorMsg String
+pub suberror ErrorMsg {
+  ErrorMsg(String)
+}
 
 // Types and methods
 pub(all) enum Spec {


### PR DESCRIPTION
Automated cleanup for nightly regressions: run moon fmt/info/check and fix deprecated/deprecated_syntax warnings.