### PR TITLE
Fix MoonBit warnings for 2026-05-09 promotion

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -10,10 +10,10 @@ the command-line interface.
 using @ArgParser {parse}
 
 ///|
-let verbose : Ref[Bool] = Ref::new(false)
+let verbose : Ref[Bool] = Ref(false)
 
 ///|
-let output : Ref[String] = Ref::new("output")
+let output : Ref[String] = Ref("output")
 
 ///|
 let files : Array[String] = []

--- a/arg_test.mbt
+++ b/arg_test.mbt
@@ -1,8 +1,8 @@
 ///|
 test {
-  let verbose : Ref[Bool] = Ref::new(true)
-  let keyword : Ref[String] = Ref::new("")
-  let delete_files : Ref[Bool] = Ref::new(false)
+  let verbose : Ref[Bool] = Ref(true)
+  let keyword : Ref[String] = Ref("")
+  let delete_files : Ref[Bool] = Ref(false)
   let usage =
     #| Awesome CLI tool!
     #| usage: 


### PR DESCRIPTION
## Summary
- Fix MoonBit warnings reported by the community-cakes dashboard for the 2026-05-09 promotion run.
- Update deprecated APIs and debug assertions as needed.

## Validation
- `moon check --target all`
- `moon fmt`
- Tests were run where feasible during the promotion pass.
